### PR TITLE
Exclude all @mozilla.com email addresses.

### DIFF
--- a/friends.py
+++ b/friends.py
@@ -40,6 +40,14 @@ def generate_email_param(address, count):
     }
 
 
+def exclude_mozilla_addresses():
+    return {
+        'emailtype999': 'notsubstring',
+        'emailassigned_to999': '1',
+        'email999': '@mozilla.com'
+    }
+
+
 def generate_from_date_param(days_ago):
     'Returns the date seven days ago in the YYYY-MM-DD format.'
     date_str = (datetime.now() - timedelta(days=days_ago)).strftime('%Y-%m-%d')
@@ -59,6 +67,7 @@ def convert_to_wiki_markup(json):
     return '\n'.join(output)
 
 params.update(generate_from_date_param(7))
+params.update(exclude_mozilla_addresses())
 with open('emails.txt', 'r') as f:
     for i, email in enumerate(f, start=1):
         email = email.strip()  # Remove newline


### PR DESCRIPTION
This patch excludes everyone with a @mozilla.com email address from "Friends of the mobile team".
